### PR TITLE
Footer ocupa apenas o final da página, e mudança no layout

### DIFF
--- a/genre.html
+++ b/genre.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <main>
     <!-- Navbar -->
   <header class="navbar">
     <a href="index.html" class="logo">Roletando</a>
@@ -44,14 +45,26 @@
     <p id="modalOverview"></p>
   </div>
 </div>
-
+</main>
 <!-- Rodapé -->
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>&copy; 2025 Roletando. </p>
+<footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
     </div>
-  </footer>
+
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
 
   <script src="script.js"></script>
 </body>

--- a/genrelist.html
+++ b/genrelist.html
@@ -1,40 +1,51 @@
 <!DOCTYPE html>
 <html lang="pt-br">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Gêneros</title>
-  <link rel="stylesheet" href="style.css">
+ <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+ <title>Gêneros</title>
+ <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-  <header class="navbar">
-    <a href="index.html" class="logo">Roletando</a>
-    <div class="search-bar">
-      <input type="text" id="searchInput" class="search-input" placeholder="Buscar filme...">
-      <button onclick="handleSearch()" class="search-btn">Pesquisar</button>
-    </div>
-    <nav>
-      <a href="index.html">Início</a>
-      <a href="genrelist.html" class="active">Gêneros</a>       
+ <header class="navbar">
+  <a href="index.html" class="logo">Roletando</a>
+  <div class="search-bar">
+   <input type="text" id="searchInput" class="search-input" placeholder="Buscar filme...">
+   <button onclick="handleSearch()" class="search-btn">Pesquisar</button>
+  </div>
+  <nav>
+   <a href="index.html">Início</a>
+   <a href="genrelist.html" class="active">Gêneros</a>    
         <a href="minhaslistas.html">Minhas Listas</a>
-    </nav>
-    <div class="profile-icon">👤</div>
-  </header>
-  
-  <main class="container">
-    <h1 id="genrelistTitle">Explorar Gêneros</h1>
-    <div id="genresContainer" class="genres-grid">
-          </div>
-  </main>
+  </nav>
+  <div class="profile-icon">👤</div>
+ </header>
+ 
+ <main class="container">
+  <h1 id="genrelistTitle">Explorar Gêneros</h1>
+  <div id="genresContainer" class="genres-grid">
+     </div>
+ </main>
 
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>© 2025 Roletando. </p>
-    </div>
-  </footer>
+ <footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
+    </div>
 
-  <script src="script.js"></script>
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
+ <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -181,12 +181,24 @@
 </main>
 
   <!-- ======= footer ======= -->
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>&copy; 2025 Roletando. </p>
+<footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
     </div>
-  </footer>
+
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
 
   <script src="script.js"></script>
 </body>

--- a/login.html
+++ b/login.html
@@ -3,13 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Login</title>
-  <style>
-    body { text-align: center; padding: 50px; font-family: sans-serif; }
-    input, button { padding: 0.5rem; margin: 0.5rem; }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
+  <main>
     <!-- Navbar -->
   <header class="navbar">
     <a href="index.html" class="logo">Roletando</a>
@@ -47,16 +45,25 @@
         alert('Usuário ou senha inválidos!');
       }
     }
-
-    <!-- Rodapé -->
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>&copy; 2025 Roletando. </p>
+    </script>
+  </main>
+ <footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
     </div>
-  </footer>
-  
-  </script>
 
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -93,12 +93,24 @@
   </main>
 
   <!-- Rodapé -->
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>&copy; 2025 Roletando. </p>
+<footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
     </div>
-  </footer>
+
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
 
   <script src="profile.js"></script>
 </body>

--- a/register.html
+++ b/register.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Cadastro</title>
-  <style>
-    body { text-align: center; padding: 50px; font-family: sans-serif; }
-    input, button { padding: 0.5rem; margin: 0.5rem; }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <main>
 <!-- Navbar -->
   <header class="navbar">
     <a href="index.html" class="logo">Roletando</a>
@@ -23,7 +22,6 @@
     </nav>
     <div class="profile-icon">👤</div>
   </header>
-
 
   <h1>Cadastro</h1>
   <input type="text" id="username" placeholder="Nome de usuário"><br>
@@ -61,16 +59,26 @@
         window.location.href = 'profile.html';
       }
     }
-
-    <!-- Rodapé -->
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>&copy; 2025 Roletando. </p>
-    </div>
-  </footer>
-  
   </script>
+  </main>
+    <!-- Rodapé -->
+<footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
+    </div>
 
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const API_TOKEN = 'x';
+const API_TOKEN = 'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJlNGQyYmU3YmU4ZDc3NDAxNjBkM2Y5YjJhNTg2MGUzYiIsIm5iZiI6MTc0ODgwMjE4MC42OTgsInN1YiI6IjY4M2M5YTg0OWQzYzgzMjU1NTI4OGMzZSIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.I3vkGUePNaq8IvW_vEB795js7lzNYSAt5gYiFkCGaEA';
 
 let currentPage = 1;
 let totalPages = 1;

--- a/search.html
+++ b/search.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-    <header class="navbar">
+  <main>
+        <header class="navbar">
     <a href="index.html" class="logo">Roletando</a>
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Buscar filme...">
@@ -47,15 +47,26 @@
       <span id="searchPageIndicator">Página 1</span>
       <button onclick="nextSearchPage()">Próxima ➡️</button>
     </div>
-
+    </main>
   <!-- Rodapé -->
-  <footer class="footer">
-    <button class="button-btn">Contato</button>
-    <div class="footer-things">
-      <p>&copy; 2025 Roletando. </p>
+  <footer class="custom-footer">
+  <div class="footer-top">
+    <div class="footer-about">
+      <h2>🎬 Roletando</h2>
+      <p>Descubra novos filmes com uma roleta personalizada. Escolha, gire e surpreenda-se.</p>
     </div>
-  </footer>
 
+    <div class="footer-links">
+      <ul>
+        <li><a href="index.html" class="active">Início</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2025 Roletando. Todos os direitos reservados.</p>
+  </div>
+</footer>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,9 @@ body, html {
   text-align: center;
 }
 
+main {
+  flex-grow: 1; 
+}
 
 .navbar {
   display: flex;
@@ -379,48 +382,61 @@ body, html {
   border-radius: 10px;
 }
 
-.footer {
-  background-color: #350756;
-  color: white;
-  padding: 20px;
+.custom-footer {
+  background-color: #41055b;
+ color: #bbb;
+  font-size: 14px;
+  padding: 20px 10px 10px;
+  font-family: 'Segoe UI', sans-serif;
   text-align: center;
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
 }
 
-footer.footer {
-  bottom: 0;
-  width: 100%;
-  height: 70px;
-
-}
-
-.footer .button-btn {
-  margin-top: 10px;;
-  margin-left: 20px;
-  padding: 0.8rem 1.0rem;
-  font-size: 1rem;
-  background-color: #7a30e3;
-  color: #fff;
-  border: none;
-  border-radius: 1rem;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-  height: 50px;
-}
-
-.footer .button-btn:hover {
-  background-color: #20013f;
-}
-
-.footer .footer-things {
+.footer-top {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 10px;
-  margin-right: 70px;
+  gap: 15px;
+  margin-bottom: 10px;
 }
+
+.footer-about h2 {
+  color: #fff;
+  font-size: 18px;
+  margin-bottom: 10px;
+}
+
+.footer-about p {
+  max-width: 500px;
+  line-height: 1.6;
+  margin: 0 auto;
+}
+
+.footer-links ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+}
+
+.footer-links ul li a {
+  color: #bbb;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-links ul li a:hover {
+  color: #fff;
+}
+
+.footer-bottom {
+  border-top: 2px solid #6e1b83;
+  padding-top: 10px;
+  font-size: 13px;
+  color: #666;
+}
+
 
 .filmes-row-wrapper {
   position: relative;


### PR DESCRIPTION
## Summary by Sourcery

Revamp the footer layout and styling across all pages to ensure it sticks to the bottom, replace inline footer code with a unified custom-footer component, remove inline page styles in favor of external CSS, and update the API token constant.

Enhancements:
- Make the main content flex-grow to push the footer to the bottom of the viewport
- Replace the old .footer class with a .custom-footer component including .footer-top, .footer-about, .footer-links, and .footer-bottom sections
- Remove inline styles and <style> blocks in register and login pages and link to the shared stylesheet
- Wrap page content in <main> tags for better semantic structure
- Update viewport meta tags for mobile responsiveness

Chores:
- Replace the placeholder API_TOKEN constant with the actual JWT token